### PR TITLE
Correctly handle multi-line <span>s

### DIFF
--- a/lib/octopress-code-highlighter/renderer.rb
+++ b/lib/octopress-code-highlighter/renderer.rb
@@ -1,3 +1,5 @@
+require_relative "span_splitter"
+
 module Octopress
   module CodeHighlighter
     class Renderer
@@ -30,10 +32,10 @@ module Octopress
           $stderr.puts 'No syntax highlighting:'.yellow
           $stderr.puts "\tInstall pygments.rb, rouge".yellow
         end
-  
+
         'plain'
       end
-      
+
       def renderer_available?(which)
         Gem::Specification::find_all_by_name(which).any?
       end
@@ -44,6 +46,7 @@ module Octopress
         else
           rendered_code = render
           rendered_code = escape_characters(rendered_code)
+          rendered_code = SpanSplitter.split(rendered_code)
           rendered_code = tableize_code(rendered_code)
           classnames = 'code-highlight-figure'
           if options[:class]
@@ -79,14 +82,14 @@ module Octopress
       end
 
       def render_plain
-        @code.gsub('<','&lt;') 
+        @code.gsub('<','&lt;')
       end
 
       def render_pygments
         if lexer = Pygments::Lexer.find(lang) || Pygments::Lexer.find(@aliases[lang])
           begin
             options = { encoding: 'utf-8' }
-            if lang =~ /php/ 
+            if lang =~ /php/
               options[:startinline] = @options[:startinline] || true
             end
             lexer.highlight @code, {
@@ -179,4 +182,3 @@ module Octopress
     end
   end
 end
-

--- a/lib/octopress-code-highlighter/span_splitter.rb
+++ b/lib/octopress-code-highlighter/span_splitter.rb
@@ -1,0 +1,32 @@
+module Octopress
+  module CodeHighlighter
+    class SpanSplitter
+      START_REGEX = %r{(<span[^>]*>)(?:(?!</span>).)*$}
+      END_REGEX = %r{^[^<]*</span>}
+
+      def self.split(code)
+        new(code).call
+      end
+
+      def initialize(code)
+        @code = code
+      end
+
+      def call
+        active_span = nil
+        code.lines.map do |line|
+          prefix = active_span || ""
+          active_span = nil if END_REGEX =~ line
+          match = START_REGEX.match(line)
+          active_span = match[1] if match
+          suffix = active_span ? "</span>" : ""
+          "#{prefix}#{line.chomp}#{suffix}\n"
+        end.join
+      end
+
+      private
+
+      attr_reader :code
+    end
+  end
+end

--- a/spec/pygments_spec.rb
+++ b/spec/pygments_spec.rb
@@ -37,6 +37,15 @@ EOF
 EOF
   end
 
+  let(:expected_output_lang_json) do
+    <<-EOF
+<figure class='code-highlight-figure'><div class='code-highlight'><pre class='code-highlight-pre'><div data-line='1' class='code-highlight-row numbered'><div class='code-highlight-line'><span class="p">&#x7b;</span><span class="w"></span>
+</div></div><div data-line='2' class='code-highlight-row numbered'><div class='code-highlight-line'><span class="w">  </span><span class="nt">"name"</span><span class="p">:</span><span class="w"> </span><span class="s2">"code-highlihting"</span><span class="w"></span>
+</div></div><div data-line='3' class='code-highlight-row numbered'><div class='code-highlight-line'><span class="p">&#x7d;</span><span class="w"></span>
+</div></div></pre></div></figure>
+EOF
+  end
+
   let(:code) do
     <<-EOF
 require "hi-there-honey"
@@ -48,6 +57,14 @@ end
 hi-there-honey
 # =>  "Hi, your name"
     EOF
+  end
+
+  let(:json) do
+    <<-EOF
+{
+  "name": "code-highlihting"
+}
+EOF
   end
 
   let(:markup) do
@@ -105,6 +122,12 @@ hi-there-honey
     context "with a language" do
       it "returns the right HTML for a given set of code" do
         expect(described_class.highlight(code, { lang: 'abc', aliases: {'abc'=>'ruby'}, escape: true, class: 'awesome' })).to eql(expected_output_lang_ruby.chop)
+      end
+    end
+
+    context "with multi-line spans" do
+      it "splits the spans into their own lines" do
+        expect(described_class.highlight(json, { lang: 'json' })).to eql(expected_output_lang_json.chomp)
       end
     end
   end

--- a/spec/span_splitter_spec.rb
+++ b/spec/span_splitter_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+require 'octopress-code-highlighter/span_splitter'
+
+describe Octopress::CodeHighlighter::SpanSplitter do
+  subject(:result) { described_class.split(code) }
+
+  describe ".call" do
+    context "with a single-line span" do
+      let(:code) { %(<span class="k">end</span>\n) }
+
+      it "leaves the code as-is" do
+        expect(result).to eql(code)
+      end
+    end
+
+    context "with a 2-line span" do
+      let(:code) do
+        <<-EOF
+<span class="w">
+  </span>
+EOF
+      end
+      let(:expected) do
+        <<-EOF
+<span class="w"></span>
+<span class="w">  </span>
+EOF
+      end
+
+      it "splits the span across both lines" do
+        expect(result).to eql(expected)
+      end
+    end
+
+    context "with a multi-line span" do
+      let(:code) do
+        <<-EOF
+<span class="s">"""
+  Some text
+"""</span>
+EOF
+      end
+      let(:expected) do
+        <<-EOF
+<span class="s">"""</span>
+<span class="s">  Some text</span>
+<span class="s">"""</span>
+EOF
+      end
+
+      it "splits the span across all lines" do
+        expect(result).to eql(expected)
+      end
+    end
+
+    context "with a mix of single-line and multi-line spans" do
+      let(:code) do
+        <<-EOF
+<span class="w">  </span><span class="p">{</span><span class="w">
+    </span><span class="s">Some text</span><span class="w">
+  </span><span class="p">}</span>
+EOF
+      end
+      let(:expected) do
+        <<-EOF
+<span class="w">  </span><span class="p">{</span><span class="w"></span>
+<span class="w">    </span><span class="s">Some text</span><span class="w"></span>
+<span class="w">  </span><span class="p">}</span>
+EOF
+      end
+
+      it "preserves the single-line spans and splits the multi-line spans" do
+        expect(result).to eql(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
With some code blocks, the highlighter might produce a `<span>` element that "spans" multiple lines.  When that happens, the `tableize_code` method will generate HTML that nests `<div>`s inside the mutli-line `<span>`.

With the current code, the result of this:

```
{% codeblock Minimal package.json lang:json %}
{
  "name": "@",
  "main": ""
}
{% endcodeblock %}
```

is this:

![screen shot 2016-10-05 at 6 03 47 am](https://cloud.githubusercontent.com/assets/1406203/19139746/089f042c-8b3c-11e6-8ab4-e8591d0217e9.png)

This PR addresses the issue by detecting these multi-line spans and splitting them, so that each span lives on its own line.  That way, `tableize_code` can't mess up the formatting.

With this fix in place, the above codeblock now looks like this:

![screen shot 2016-10-05 at 8 35 07 pm](https://cloud.githubusercontent.com/assets/1406203/19139762/344fe64a-8b3c-11e6-8a19-4b79d0cf267e.png)

This may not be the best way to accomplish the goal of having correct formatting, for a few reasons:
- I've violated the cardinal rule: [Never parse HTML with regexes](http://stackoverflow.com/a/1732454/667070).  That said, we're looking for a very specific pattern, so maybe it's ok here?
- The regex for finding the start pattern uses negative lookahead.  In addition to being pretty deep in the bag of tricks, it can also result in relatively slow performance.  I ran this code against my blog of 212 posts (after deleting the code highlighting cache) and didn't notice a significant difference in generation time, but YMMV.

Both Rouge and Pygments have an option to generate their own line numbers.  It might be better to lean on those features.  However, the resulting markup is different for each of them, and it would be harder to accomplish the goal of being able to mark lines in code blocks, which is a lot of what `tableize_code` is doing.

Note that I pulled the span-splitting code into its own class to make it easier to test.  I included a higher-level test of the formatter itself as well.  If the extra class isn't desirable, I can merge the implementation back in.  But if you like this approach, there's some opportunity to refactor out some of the other work being done in the `Renderer`.
